### PR TITLE
Change this.fmt to allow empty string for no format.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ function Prompt(options, rl) {
   this.formats.option = this.formats.select || '%s) %s';
 
   this.name = options.name || path.basename(process.argv[1]);
-  this.fmt = options.format ||
-    ':name :delimiter :health :location :status :message :default';
+  this.fmt = (options.format === '' ? '' :
+    (options.format || ':name :delimiter :health :location :status :message :default'));
 
   options.validator = options.validator !== undefined
     ? options.validator : {};


### PR DESCRIPTION
When user specifies blank string for 'delimiter' and 'name', blank string is coerced into null and causes file name and lightning-symbol to appear.

When user specifies space-character string (' '), a space is placed before the cursor.
![image](https://cloud.githubusercontent.com/assets/11944012/12244981/26eaf0e4-b874-11e5-97f2-be69182dce86.png)

This small change allows the user to specify a blank string ('') as the 'format' option in order to remove all formatting and spaces before the cursor.
![image](https://cloud.githubusercontent.com/assets/11944012/12245015/5bd99378-b874-11e5-85eb-f8dd943b7531.png)
